### PR TITLE
Remote File Storage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,23 @@ pip install -r requirements.txt # (first time only)
 
 ### Model File Storage
 
-To classify text, this app needs access to the model's final weights file, which we're hosting on a publicly-available Google Cloud Storage bucket called ["trumpmeter-bucket"](https://console.cloud.google.com/storage/browser/trumpmeter-bucket/).
+To classify text, this app needs access to certain model-related files, which we're hosting on a publicly-available Google Cloud Storage bucket called ["trumpmeter-bucket"](https://console.cloud.google.com/storage/browser/trumpmeter-bucket/).
 
-  + Download the dictionary files (`gs://trumpmeter-bucket/model/dictionaries`) and move them into the local "model/dictionaries" directory.
-  + Download the final model weights file (`gs://trumpmeter-bucket/model/weights/weights-reconstructed.hdf5`) and move it into the local "model/weights" directory.
+  + `gs://trumpmeter-bucket/model/weights/weights-reconstructed.hdf5`
+  + `gs://trumpmeter-bucket/model/dictionaries`
+
+Feel free to use the files in this bucket (i.e. "remote" storage option), or download them into your local repository for faster file-load times (i.e. "local" storage option). Depending on which storage option you choose ("local" or "remote"), set the environment variable `STORAGE_ENV` accordingly. If choosing the "remote" storage option: download your Google Cloud API service account credentials and set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable accordingly.
+
+After configuring your storage option, run the storage service to verify all files are in place:
+
+```sh
+python -m app.storage_service
+# OR
+STORAGE_ENV="local" python -m app.storage_service
+# OR
+STORAGE_ENV="remote" python -m app.storage_service
+```
+
 
 ## Usage
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -2,7 +2,7 @@
 
 This is a (re)production of the original Trumpmeter, by Zhechao Huang, with training contributions by Andrew _____.
 
-See also: the [Brexitmeter](https://github.com/zaman-lab/brexitmeter-py).
+See also: the [Brexitmeter](https://github.com/zaman-lab/brexitmeter-py) and [BrexitMeter Credits](https://github.com/zaman-lab/brexitmeter-py/blob/master/CREDITS.md).
 
 ## NPY Files
 

--- a/app/client.py
+++ b/app/client.py
@@ -3,7 +3,7 @@ from pprint import pprint
 import os
 
 from conftest import EXAMPLE_TWEETS
-from app.model import reconstructed_final_model
+from app.model import production_model #reconstructed_final_model
 from app.helper_text import main_clean
 
 def classify(txt, model):
@@ -23,7 +23,7 @@ def classify(txt, model):
 
 if __name__ == "__main__":
 
-    model = reconstructed_final_model()
+    model = production_model() # reconstructed_final_model()
 
     for twt in EXAMPLE_TWEETS:
         print("\n-----------------------------")

--- a/app/dictionaries.py
+++ b/app/dictionaries.py
@@ -2,12 +2,21 @@
 import os
 from gensim.corpora import Dictionary
 
-DICTIONARIES_DIRPATH = os.path.join(os.path.dirname(__file__), "..", "model", "dictionaries")
+from app.storage_service import STORAGE_ENV, dictionaries_dirpath
 
-def load_dictionaries():
-	print("LOADING DICTIONARIES...")
-	dict1 = Dictionary.load(os.path.join(DICTIONARIES_DIRPATH, "dic.txt"))
-	dict2 = Dictionary.load(os.path.join(DICTIONARIES_DIRPATH, "dic_s.txt"))
+def load_dictionaries(storage_env="local"):
+	dirpath = dictionaries_dirpath(storage_env)
+	if storage_env == "local":
+		dict1 = Dictionary.load(os.path.join(dirpath, "dic.txt"))
+		dict2 = Dictionary.load(os.path.join(dirpath, "dic_s.txt"))
+	elif storage_env == "remote":
+		# todo: construct Dictionary objects from remote file contents
+		# texts = [
+		# 	['human', 'interface', 'computer']
+		# ]
+		# my_dict = Dictionary(texts)
+		raise NotImplementedError
+
 	return dict1, dict2
 
 if __name__ == "__main__":

--- a/app/model.py
+++ b/app/model.py
@@ -13,10 +13,17 @@ from keras.layers.merge import concatenate
 from keras.models import Model, load_model
 
 from app.dictionaries import load_dictionaries
+from app.storage_service import weights_filepath
 
 ORIGINAL_WEIGHTS_FILEPATH = os.path.join(os.path.dirname(__file__), "..", "model", "weights", "weights-improvement-01-0.91.hdf5")
 FINAL_MODEL_FILEPATH = os.path.join(os.path.dirname(__file__),"..", "model", "final_model.h5")
 FINAL_WEIGHTS_FILEPATH = os.path.join(os.path.dirname(__file__), "..", "model", "weights", "weights-reconstructed.hdf5")
+
+def production_model():
+	model = unweighted_model()
+	print("LOADING MODEL WEIGHTS...")
+	model.load_weights(weights_filepath())
+	return model
 
 def reconstructed_final_model(idempotent=True):
     if idempotent == False:

--- a/app/storage_service.py
+++ b/app/storage_service.py
@@ -10,13 +10,13 @@ import tensorflow as tf # from tensorflow.io import gfile
 load_dotenv()
 
 STORAGE_ENV = os.getenv("STORAGE_ENV", default="local") # "local" OR "remote"
-GOOGLE_APPLICATION_CREDENTIALS = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", default="google-credentials.json") # implicit check by google.cloud (and keras)
-GOOGLE_STORAGE_PATH=os.getenv("GOOGLE_STORAGE_PATH", default="gs://trumpmeter-bucket")
+GOOGLE_APPLICATION_CREDENTIALS = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", default="/abspath/to/google-credentials.json") # implicit check by google.cloud (and keras)
+GOOGLE_STORAGE_PATH= os.getenv("GOOGLE_STORAGE_PATH", default="gs://trumpmeter-bucket")
 
 def storage_path(storage_env=STORAGE_ENV):
 	storage_paths = {
 		"local": os.path.join(os.path.dirname(__file__), "..", "model"),
-		"remote": GOOGLE_STORAGE_PATH
+		"remote": os.path.join(GOOGLE_STORAGE_PATH, "model")
 	}
 	return storage_paths[storage_env]
 

--- a/app/storage_service.py
+++ b/app/storage_service.py
@@ -1,0 +1,50 @@
+
+
+
+
+import os
+from dotenv import load_dotenv
+from google.cloud import storage
+import tensorflow as tf # from tensorflow.io import gfile
+
+load_dotenv()
+
+STORAGE_ENV = os.getenv("STORAGE_ENV", default="local") # "local" OR "remote"
+GOOGLE_APPLICATION_CREDENTIALS = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", default="google-credentials.json") # implicit check by google.cloud (and keras)
+GOOGLE_STORAGE_PATH=os.getenv("GOOGLE_STORAGE_PATH", default="gs://trumpmeter-bucket")
+
+def storage_path(storage_env=STORAGE_ENV):
+	storage_paths = {
+		"local": os.path.join(os.path.dirname(__file__), "..", "model"),
+		"remote": GOOGLE_STORAGE_PATH
+	}
+	return storage_paths[storage_env]
+
+def weights_filepath(storage_env=STORAGE_ENV):
+	return os.path.join(storage_path(storage_env), "weights", "weights-reconstructed.hdf5")
+
+def dictionaries_dirpath(storage_env=STORAGE_ENV):
+	return os.path.join(storage_path("local"), "dictionaries")
+
+def my_buckets():
+	storage_client = storage.Client()
+	buckets = list(storage_client.list_buckets())
+	return buckets
+
+if __name__ == "__main__":
+
+	if STORAGE_ENV == "remote":
+		print("------------")
+		print("MY BUCKETS:")
+		for bucket in my_buckets():
+			print(bucket)
+
+	print("------------")
+	print(f"{STORAGE_ENV.upper()} MODEL FILES:")
+	model_filepaths = [
+		weights_filepath(STORAGE_ENV),
+		os.path.join(dictionaries_dirpath(STORAGE_ENV), "dic.txt"),
+		os.path.join(dictionaries_dirpath(STORAGE_ENV), "dic_s.txt"),
+	]
+	for filepath in model_filepaths:
+		print(os.path.abspath(filepath), tf.io.gfile.exists(filepath))

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -1,6 +1,6 @@
 
 
-from app.model import original_model, saved_final_model, reconstructed_final_model
+from app.model import original_model, saved_final_model, reconstructed_final_model, production_model
 from app.client import classify
 
 def test_original_classifications():
@@ -28,8 +28,9 @@ def test_final_classifications():
     # these two models should give the same results
     model_from_file = saved_final_model()
     model_from_weights = reconstructed_final_model()
+    model_from_storage_service = production_model()
 
-    for model in [model_from_file, model_from_weights]:
+    for model in [model_from_file, model_from_weights, model_from_storage_service]:
 
         r1 = classify("Make america great again! Trump for President! #MAGA", model)
         #assert r1["pro_trump"] == [0.0133, 0.9867]

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -5,7 +5,7 @@ from keras.engine.training import Model
 from app.model import (
     ORIGINAL_WEIGHTS_FILEPATH, FINAL_MODEL_FILEPATH, FINAL_WEIGHTS_FILEPATH,
     unweighted_model, original_model,
-    saved_final_model, reconstructed_final_model
+    saved_final_model, reconstructed_final_model, production_model
 )
 
 def test_filepaths():
@@ -24,3 +24,6 @@ def test_saved_final_model():
 
 def test_reconstructed_final_model():
     assert isinstance(reconstructed_final_model(), Model)
+
+def test_production_model():
+    assert isinstance(production_model(), Model)

--- a/test/storage_service_test.py
+++ b/test/storage_service_test.py
@@ -1,0 +1,23 @@
+
+import os
+import tensorflow as tf
+
+from app.storage_service import weights_filepath, dictionaries_dirpath
+
+def test_local_storage():
+    local_filepaths = [
+		weights_filepath("local"),
+		os.path.join(dictionaries_dirpath("local"), "dic.txt"),
+		os.path.join(dictionaries_dirpath("local"), "dic_s.txt"),
+	]
+    for filepath in local_filepaths:
+        assert os.path.isfile(filepath)
+
+def test_remote_storage():
+    remote_filepaths = [
+		weights_filepath("remote"),
+		os.path.join(dictionaries_dirpath("remote"), "dic.txt"),
+		os.path.join(dictionaries_dirpath("remote"), "dic_s.txt"),
+	]
+    for filepath in remote_filepaths:
+        assert tf.io.gfile.exists(filepath)


### PR DESCRIPTION
The model weights file is too large to push to a production Heroku server, so we need to host them on Google Cloud Storage instead and access them from there. This PR allows the model to be compiled using these remote weights.